### PR TITLE
Add Weight property to Athlete.

### DIFF
--- a/StravaDotNet/Athletes/Athlete.cs
+++ b/StravaDotNet/Athletes/Athlete.cs
@@ -73,6 +73,12 @@ namespace Strava.Athletes
         public int? Ftp { get; set; }
 
         /// <summary>
+        /// The functional threshold power.
+        /// </summary>
+        [JsonProperty("weight")]
+        public float? Weight { get; set; }
+
+        /// <summary>
         /// A list of the athlete's bikes.
         /// </summary>
         [JsonProperty("bikes")]


### PR DESCRIPTION
According to Strava documentation Athlete has a Weight property ("weight"). It's missing from the Stravadotnet Athlete object.