### PR TITLE
Added API call to retrieve related activities of an activity & fix for Starred segments requests

### DIFF
--- a/StravaDotNet/Clients/ActivityClient.cs
+++ b/StravaDotNet/Clients/ActivityClient.cs
@@ -278,6 +278,19 @@ namespace Strava.Clients
         }
 
         /// <summary>
+        /// Retrieves the related activities of an activity asynchronously.
+        /// </summary>
+        /// <param name="activityId">The Strava activity Id.</param>
+        /// <returns>A list of activies.</returns>
+        public async Task<List<ActivitySummary>> GetRelatedActivitiesAsync(string activityId)
+        {
+            string getUrl = string.Format("{0}/{1}/related?access_token={2}", Endpoints.Activity, activityId, Authentication.AccessToken);
+            string json = await Http.WebRequest.SendGetAsync(new Uri(getUrl));
+
+            return Unmarshaller<List<ActivitySummary>>.Unmarshal(json);
+        }
+
+        /// <summary>
         /// Gets all the activities asynchronously. Pagination is supported.
         /// </summary>
         /// <param name="page">The page of activities.</param>
@@ -289,7 +302,7 @@ namespace Strava.Clients
             string json = await Http.WebRequest.SendGetAsync(new Uri(getUrl));
 
             return Unmarshaller<List<ActivitySummary>>.Unmarshal(json);
-        }
+        }        
 
         /// <summary>
         /// Gets the latest activities of the currently authenticated athletes followers asynchronously.
@@ -919,6 +932,19 @@ namespace Strava.Clients
             string json = Http.WebRequest.SendGet(new Uri(getUrl));
 
             return Unmarshaller<List<ActivityZone>>.Unmarshal(json);
+        }
+
+        /// <summary>
+        /// Retrieves the related activities of an activity.
+        /// </summary>
+        /// <param name="activityId">The Strava activity Id.</param>
+        /// <returns>A list of activies.</returns>
+        public List<ActivitySummary> GetRelatedActivities(string activityId)
+        {
+            string getUrl = string.Format("{0}/{1}/related?access_token={2}", Endpoints.Activity, activityId, Authentication.AccessToken);
+            string json = Http.WebRequest.SendGet(new Uri(getUrl));
+
+            return Unmarshaller<List<ActivitySummary>>.Unmarshal(json);
         }
 
         /// <summary>

--- a/StravaDotNet/Clients/SegmentClient.cs
+++ b/StravaDotNet/Clients/SegmentClient.cs
@@ -364,7 +364,7 @@ namespace Strava.Clients
         /// <returns>A list of segments that are starred by the currently authenticated athlete.</returns>
         public async Task<List<SegmentSummary>> GetStarredSegmentsAsync()
         {
-            string getUrl = string.Format("{0}/?access_token={1}", Endpoints.Starred, Authentication.AccessToken);
+            string getUrl = string.Format("{0}?access_token={1}", Endpoints.Starred, Authentication.AccessToken);
             string json = await WebRequest.SendGetAsync(new Uri(getUrl));
 
             return Unmarshaller<List<SegmentSummary>>.Unmarshal(json);
@@ -376,7 +376,7 @@ namespace Strava.Clients
         /// <returns>A list of segments that are starred by the athlete.</returns>
         public async Task<List<SegmentSummary>> GetStarredSegmentsAsync(string athleteId)
         {
-            string getUrl = string.Format("https://www.strava.com/api/v3/athletes/{0}/segments/starred/?access_token={1}", athleteId, Authentication.AccessToken);
+            string getUrl = string.Format("https://www.strava.com/api/v3/athletes/{0}/segments/starred?access_token={1}", athleteId, Authentication.AccessToken);
             string json = await WebRequest.SendGetAsync(new Uri(getUrl));
 
             return Unmarshaller<List<SegmentSummary>>.Unmarshal(json);


### PR DESCRIPTION
Current StravaDotNet lib was missing the ability to retrieve related activities of a given activity.
Very common when you want to show all other athletes that participated in your activity.

Starred segments url formatting was incorrect
