### PR TITLE
Fixed GetFriends(id) method to return friends of specified athlete

### DIFF
--- a/StravaDotNet/Clients/AthleteClient.cs
+++ b/StravaDotNet/Clients/AthleteClient.cs
@@ -85,7 +85,7 @@ namespace Strava.Clients
         /// <returns>The list of friends of the athlete.</returns>
         public async Task<List<AthleteSummary>> GetFriendsAsync(string athleteId)
         {
-            string getUrl = string.Format("{0}/friends?access_token={1}", Endpoints.Athlete, Authentication.AccessToken);
+            string getUrl = string.Format("{0}/{1}/friends?access_token={1}", Endpoints.Athletes, athleteId, Authentication.AccessToken);
             string json = await WebRequest.SendGetAsync(new Uri(getUrl));
 
             return Unmarshaller<List<AthleteSummary>>.Unmarshal(json);
@@ -221,7 +221,7 @@ namespace Strava.Clients
         /// <returns>The list of friends of the athlete.</returns>
         public List<AthleteSummary> GetFriends(string athleteId)
         {
-            string getUrl = string.Format("{0}/friends?access_token={1}", Endpoints.Athlete, Authentication.AccessToken);
+            string getUrl = string.Format("{0}/{1}/friends?access_token={1}", Endpoints.Athletes, athleteId, Authentication.AccessToken);
             string json = WebRequest.SendGet(new Uri(getUrl));
 
             return Unmarshaller<List<AthleteSummary>>.Unmarshal(json);

--- a/StravaDotNet/Clients/AthleteClient.cs
+++ b/StravaDotNet/Clients/AthleteClient.cs
@@ -85,7 +85,7 @@ namespace Strava.Clients
         /// <returns>The list of friends of the athlete.</returns>
         public async Task<List<AthleteSummary>> GetFriendsAsync(string athleteId)
         {
-            string getUrl = string.Format("{0}/{1}/friends?access_token={1}", Endpoints.Athletes, athleteId, Authentication.AccessToken);
+            string getUrl = string.Format("{0}/{1}/friends?access_token={2}", Endpoints.Athletes, athleteId, Authentication.AccessToken);
             string json = await WebRequest.SendGetAsync(new Uri(getUrl));
 
             return Unmarshaller<List<AthleteSummary>>.Unmarshal(json);
@@ -221,7 +221,7 @@ namespace Strava.Clients
         /// <returns>The list of friends of the athlete.</returns>
         public List<AthleteSummary> GetFriends(string athleteId)
         {
-            string getUrl = string.Format("{0}/{1}/friends?access_token={1}", Endpoints.Athletes, athleteId, Authentication.AccessToken);
+            string getUrl = string.Format("{0}/{1}/friends?access_token={2}", Endpoints.Athletes, athleteId, Authentication.AccessToken);
             string json = WebRequest.SendGet(new Uri(getUrl));
 
             return Unmarshaller<List<AthleteSummary>>.Unmarshal(json);


### PR DESCRIPTION
The `GetFriends(athleteId)` methods (async and sync) were not passing in the specified athlete ID, thus only returning the list of friends for the _current_ athlete.
