### PR TITLE
Updating activity's commute property changes activity name instead

### DIFF
--- a/StravaDotNet/Clients/ActivityClient.cs
+++ b/StravaDotNet/Clients/ActivityClient.cs
@@ -398,7 +398,7 @@ namespace Strava.Clients
             switch (parameter)
             {
                 case ActivityParameter.Commute:
-                    param = "name";
+                    param = "commute";
                     break;
                 case ActivityParameter.Description:
                     param = "description";
@@ -1117,7 +1117,7 @@ namespace Strava.Clients
             switch (parameter)
             {
                 case ActivityParameter.Commute:
-                    param = "name";
+                    param = "commute";
                     break;
                 case ActivityParameter.Description:
                     param = "description";


### PR DESCRIPTION
Hi,

This is a fix for updating an activity's commute property - the existing code incorrectly updates the activity name instead.